### PR TITLE
Adds how to create a metapackage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Meilix
+# Meilix
 [![Build Status](https://travis-ci.org/fossasia/meilix.svg?branch=master)](https://travis-ci.org/fossasia/meilix)
 
 Beautiful [lubuntu](http://lubuntu.net) based Linux OS for Hotels and Public Spaces with a system lock.
@@ -9,12 +9,21 @@ Features:
 * Contains neccessary packages
 * PPA synced with github
 
-##Customizing Distribution
+## Customizing Distribution
 
 - After cloning open build.sh to change. Read comment in build.sh to understand how to change.
 (Note: Please not change anything at # Install core packages and do not delete any in hotelos folder).
 
-##Adding a Metapackage
+### Creating a metapackage
+Creating a metapackage is really easy, we will make use of [equivs](http://apt.ubuntu.com/p/equivs) to make our metapackage.
+- First, install equivs.
+- Now run equivs: `equivs-control ns-control`
+- It will create a file called ns-control, open this file with your text editor.
+- Modify the file to your needs modifying the needy information.
+- Then run: `equivs-build ns-control` to build your metapackage, thats all simple and easy.
+- To add it to meilix follow adding a metapackage to meilix section.
+
+### Adding a Metapackage to meilix
 - Create a metapackage and place it in the root directory of the project
 - Add it to the build.sh file
 - Install `reprepro` if you don't have it run: `sudo apt-get install reprepro`
@@ -23,5 +32,5 @@ Features:
 
 **Note: Remember to replace nameOfYourMeta-package with the name of the meta-package**
 
-##Communication
+## Communication
 Chat: [Slack Channel](http://fossasia.slack.com/messages/linux/) | [Get an Invite](http://fossasia-slack.herokuapp.com/)


### PR DESCRIPTION
Adds how to information on how metapackages can be created using equivs.

Linux has a lot of metapackages, it was indeed necessary that information be
added about how they are created to help new developers. How to add existing
metapackage to meilix was already contained in the readme under the title
"adding a metapackage",  which was now renamed to "adding a metapackage to meilix".
Github had pushed an update due to which the readme was looking bad and renderless
as the #s didnt have a space after them.

Metapackages can also be created with other tools, but equivs provide a simple solution
and that's why it has been added to the readme.

Fix last point of #1.