### PR TITLE
fix: change mount commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,9 +56,9 @@ sudo cp -v meilix-metapackages_*_all.deb chroot
 sudo cp -v meilix-metapackages-2_*_all.deb chroot
 
 # Mount needed pseudo-filesystems
-sudo mount --rbind /sys chroot/sys
-sudo mount --rbind /dev chroot/dev
-sudo mount -t proc none chroot/proc
+sudo mount -t sysfs sys chroot/sys
+sudo mount -t proc proc chroot/proc
+sudo mount -o bind /dev chroot/dev
 
 # Work *inside* the chroot
 sudo chroot chroot <<EOF
@@ -192,9 +192,9 @@ EOF
 # Continue work outside the chroot, preparing image
 
 # Unmount pseudo-filesystems
-sudo umount -lfr chroot/proc
-sudo umount -lfr chroot/sys
-sudo umount -lfr chroot/dev
+sudo umount chroot/proc
+sudo umount chroot/sys
+sudo umount chroot/dev
 
 echo $0: Preparing image...
 

--- a/build.sh
+++ b/build.sh
@@ -192,9 +192,9 @@ EOF
 # Continue work outside the chroot, preparing image
 
 # Unmount pseudo-filesystems
-sudo umount chroot/proc
-sudo umount chroot/sys
-sudo umount chroot/dev
+sudo umount -l chroot/proc
+sudo umount -l chroot/sys
+sudo umount -l chroot/dev
 
 echo $0: Preparing image...
 


### PR DESCRIPTION
This will prevent weird behavior when running sudo after running build.sh
Before this commit when using sudo after running build.sh, the following error is shown:
```
sudo: no tty present and no askpass program specified
```

This might be caused by mounting system directories into chroot.

### Short description
I have:
- [ ] There is a corresponding issue for this pull request.
- [ ] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

