### PR TITLE
Purged lxqt-powermanagement-l10n

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -168,6 +168,7 @@ apt-get -q -y install gedit
 
 #remove lxqt-powermanagement
 apt-get -q -y purge lxqt-powermanagement
+apt-get -q -y purge lxqt-powermanagement-l10n
 
 #Google custom ad
 apt-get -q -y --purge install mygoad


### PR DESCRIPTION
### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
Fixes #153 
The package lxqt-powermanagement-l10n gets installed while the lxqt-powermanagement is not installed anymore. This PR will also purge lxqt-powermanagement-l10n.
### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

