### PR TITLE
Adds packages in build.sh to be provied by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,25 @@
 # This provides us with GCC binary support so we can run bash
 language: generic
 
+# Try to supply the packages from Travis so that when we run build.sh we won't
+# be required to download them again.
+include:
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - debootstrap
+          - genisoimage
+          - p7zip-full
+          - squashfs-tools
+          - ubuntu-dev-tools
+          - dpkg-dev
+          - debhelper
+          - fakeroot
+          - devscripts
+
 sudo: required
 
 script:


### PR DESCRIPTION
### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message` >> Mentioned the issue number in the PR body

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

The packages required on the system which is used to make the iso were fetched by build.sh
using apt-get. Travis Ci allows packages to be predefined in the build environment which would
decrease the build time required.

Fixes #40 

Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>