### PR TITLE
Fixes #197: Added https in webaddress in default startpage configuration

### DIFF
--- a/meilix-default-settings/etc/skel/.mozilla/firefox/*.default/user.js
+++ b/meilix-default-settings/etc/skel/.mozilla/firefox/*.default/user.js
@@ -1,1 +1,1 @@
-user_pref("browser.startup.homepage", "http://susper.com/");
+user_pref("browser.startup.homepage", "https://susper.com/");


### PR DESCRIPTION
Fixes: #197 
### Short description:
I had added https in webaddress of firefox startpage configuration.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

