### PR TITLE
scripts/release_maintainer.sh: Removes typo

### DIFF
--- a/scripts/releases_maintainer.sh
+++ b/scripts/releases_maintainer.sh
@@ -42,7 +42,7 @@ for i in $response; do
                 delete=1
             else
                 echo "Release was made this month, trying to compare date"
-                if [ $((current_day-$published_day)) -gt 10 ]; then
+                if [ $((current_day-published_day)) -gt 10 ]; then
                     echo "Release was made before more than 10 days, deleting:"
                     delete=1
                 else


### PR DESCRIPTION
Removes typo in line no: 45 which leads to issue #301.
There are two ways to do substraction in bash, one internally and the
other by using an external program such as `expr`. Using expr slows
down the execution and hence decided to do substraction internally
using the syntax:
         $((var1-var2))

Fixes #301 
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>

### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

