### PR TITLE
This changes release notes url to the meilix repository - (Solves- #407)

### DIFF
--- a/image/.disk/release_notes_url
+++ b/image/.disk/release_notes_url
@@ -1,1 +1,1 @@
-https://wiki.ubuntu.com/Lubuntu/
+https://github.com/fossasia/meilix


### PR DESCRIPTION
### Short description
This changes release_notes_url to link for this repository

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

Fixes #407 