### PR TITLE
This switches off the lxqt-notifications on autostart - (Solves- #133)

### DIFF
--- a/scripts/chroot_reconst.sh
+++ b/scripts/chroot_reconst.sh
@@ -58,12 +58,8 @@ rm  /usr/share/xsessions/plasma.desktop
 # ugliest hack ever
 cp  /usr/share/xsessions/lxqt.desktop /usr/share/xsessions/plasma.desktop
 
-# This switches off notifications(autostart)
-rm /etc/xdg/autostart/lxqt-notifications.desktop
-
 # Installing 
 apt-get -qq -y install git
-
 
 # Installing sublime text editor
 wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | apt-key add -

--- a/scripts/chroot_reconst.sh
+++ b/scripts/chroot_reconst.sh
@@ -64,6 +64,9 @@ apt-get -qq -y remove xscreensaver
 # This switch offs the sleep mode
 sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
 
+# This switches off notifications(autostart)
+rm /etc/xdg/autostart/lxqt-notifications.desktop
+
 # Installing 
 apt-get -qq -y install git
 

--- a/scripts/features/disable_notification.sh
+++ b/scripts/features/disable_notification.sh
@@ -1,0 +1,2 @@
+# This switches off notifications(autostart)
+rm /etc/xdg/autostart/lxqt-notifications.desktop


### PR DESCRIPTION
### Short description
This disables the lxqt-notifications on autostart, This suggests only removing the autostart module which causes the desktop to be filled with notifications on startup.
If a user wants to reset the notifications the user can just open the `lxqt-config-notificationd`. 
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

Fixes #133 