### PR TITLE
Switching off power management for meilix - (Solves- #467)

### DIFF
--- a/scripts/features/disable_powermanagement.sh
+++ b/scripts/features/disable_powermanagement.sh
@@ -1,0 +1,2 @@
+# Switching of power management
+sed -i '$ a xset -dpms' /etc/X11/Xsession


### PR DESCRIPTION
### Short description
This switches off power management for the Meilix ISO
Using xset in the Xsession script will disable power management features for the meilix desktop.
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

Fixes #467 